### PR TITLE
Updating verbs/preposition and features in map.json.

### DIFF
--- a/data/maps.json
+++ b/data/maps.json
@@ -2,79 +2,89 @@
   "maps": {
     "Room_1": {
       "name": "Village Hut",
-      "interactive_items": ["torchlight", "panini press"],
+      "interactive_items": ["torchlight"],
+      "feature_item": {"old wooden chest": "place holder description"},
       "valid_moves": {"north": false, "south": false, "west": false, "east": true},
-      "description": "You wake up in a small, dilapidated hut in the village. The air is filled with tension, and distant oinks can be heard from outside.",
+      "description": "Awakening in a rustic village hut, surrounded by tension and distant oinks, you're compelled to reach the Abandoned Laboratory, a place of intrigue and secrets. Despite your efforts, an inexplicable force keeps returning you to the hut, making you realize that understanding the village's mysteries is essential to unlocking the laboratory's enigma. As you examine the hut's interior, you notice an old wooden chest tucked away in the corner.",
       "obj_description": "There's an unlit torchlight on the ground beside you.",
       "isPresent": true
     },
     "Room_2": {
       "name": "Abandoned Laboratory",
-      "interactive_items": ["cast", "cup"],
+      "interactive_items": ["cast"],
+      "feature_item": {"mysterious note": "place holder description"},
       "valid_moves": {"north": false, "south": false, "west": true, "east": false},
-      "description": "You enter a rundown laboratory filled with broken equipment and remnants of failed experiments. The stench of chemicals lingers in the air.",
+      "description": "As you step into the dilapidated laboratory, you're greeted by the sight of shattered equipment and remnants of past experiments gone awry. The lingering stench of chemicals permeates the air, hinting at the space's former scientific pursuits. Amidst the debris, you catch a glimpse of a weathered map, which unexpectedly reveals a hidden secret - the location of an ancient temple yet to be discovered.",
       "obj_description": "You see a plaster cast that seems significant.",
       "isPresent": true
     },
     "Room_3": {
       "name": "Ancient Temple",
-      "interactive_items": ["communicator", "lettuce"],
+      "interactive_items": ["communicator"],
+      "feature_item": {"ancient inscription": "place holder description"},
       "valid_moves": {"north": false, "south": true, "west": true, "east": true},
-      "description": "You stumble upon an ancient temple shrouded in mystery. The air is thick with an otherworldly presence, and the walls are adorned with enigmatic symbols.",
+      "description": "As you wander through the dense wilderness, you chance upon an age-old temple concealed in an aura of mystique. The air around you seems to vibrate with an otherworldly presence, and intricate enigmatic symbols decorate the temple walls, whispering untold secrets of the past. Amidst the palpable intrigue, you can't help but wonder if these symbols might guide you to a hidden crypt within the temple's depths.",
       "obj_description": "You see a communicator that seems significant.",
       "isPresent": true
     },
     "Room_4": {
       "name": "Hidden Crypt",
-      "interactive_items": ["Laser Shield", "ham"],
+      "interactive_items": ["Laser Shield"],
+      "feature_item": {"mysterious lever": "place holder description"},
       "valid_moves": {"north": true, "south": true, "west": false, "east": true},
-      "description": "You discover a hidden crypt, that may open, deep within the underground tunnels. The walls are covered in cryptic engravings, and rows of ancient coffins line the chamber.",
+      "description": "As you venture deeper into the labyrinthine underground tunnels, an astounding revelation awaits - a concealed crypt, seemingly waiting to be unlocked. The walls of this hidden chamber bear cryptic engravings, speaking of an ancient and mysterious past. Remarkably, rows of age-old coffins line the dimly lit space, hinting at its potential use as a long-forgotten Resistance Hideout, where secrets and courage intertwine to challenge oppressive forces.",
       "obj_description": "There is a laser shield glowing on the far wall.",
       "isPresent": true
     },
     "Room_5": {
       "name": "Resistance Hideout",
-      "interactive_items": ["blueprints", "bread"],
+      "interactive_items": ["blueprints"],
+      "feature_item": {"locked cabinet": "place holder description"},
       "valid_moves": {"north": false, "south": true, "west": false, "east": true},
-      "description": "You find yourself in the secret hideout of the resistance group. The room is bustling with activity, and brave fighters gather to strategize and prepare for battle.",
+      "description": "As you stealthily make your way through hidden passages, you stumble upon the clandestine hideout of the resistance group. The atmosphere hums with energy and purpose as courageous fighters congregate, diligently strategizing and arming themselves for the imminent battle within the Reactor Tunnels.",
       "obj_description": "There are blueprints on the ground.",
       "isPresent": true
     },
     "Room_6": {
       "name": "Reactor Tunnels",
-      "interactive_items": ["cell", "wine"],
+      "interactive_items": ["cell"],
+      "feature_item": {"strange vines": "place holder description"},
       "valid_moves": {"north": false, "south": true, "west": true, "east": false},
-      "description": "Navigating through dark and eerie tunnels, you approach the reactor. The air is heavy with radiation, and the sound of machinery echoes in the distance.",
+      "description": "As you cautiously tread through dim and foreboding tunnels, you draw closer to the heart of the reactor. The atmosphere becomes thick with radiation, and the distant reverberation of machinery creates an unsettling ambiance. The eerie surroundings fuel your trepidation, raising the possibility that you might stumble upon the dreaded torture chamber hidden within the depths.",
       "obj_description": "There is a power cell in the corner of the room.",
       "isPresent": true
     },
     "Room_7": {
       "name": "Torture Chamber",
-      "interactive_items": ["cutter", "boar meat"],
+      "interactive_items": ["cutter"],
+      "feature_item": {"enchanted amulet": "place holder description"},
       "valid_moves": {"north": true, "south": true, "west": true, "east": true},
-      "description": "You enter a gruesome torture chamber where captured villagers endure unspeakable horrors. The room is filled with ominous devices and the agonizing cries of the tormented.",
+      "description": "As you explore further, you come across a chilling sight - a gruesome torture chamber, serving as a nightmarish prison for captured villagers who endure unspeakable horrors. The room is adorned with ominous devices that elicit fear, and the haunting echoes of agonizing cries fill the air, hinting at the ominous presence of the Pig Mutant Stronghold lurking nearby.",
       "obj_description": "There is a plasma cutter on the ground.",
       "isPresent": true
     },
     "Room_8": {
       "name": "Pig Mutant Stronghold",
-      "interactive_items": ["message", "mayo"],
+      "interactive_items": ["message"],
+      "feature_item": {"mysterious mural": "place holder description"},
       "valid_moves": {"north": false, "south": true, "west": true, "east": true},
-      "description": "You stand before the fortified stronghold of the Pig Mutant King. The area is heavily guarded, and tortured cries of captured resistance members fill the air.",
+      "description": "As you approach the imposing fortified stronghold, you find yourself standing before the grand entrance to the Pig Mutant King's throne room. The area is heavily guarded, and the air reverberates with the haunting cries of resistance members who have been captured and subjected to unspeakable torment.",
       "obj_description": "There is a crumpled letter on the ground.",
       "isPresent": true
     },
     "Room_9": {
       "name": "Throne Room",
-      "interactive_items": ["Mutagen Sample", "cheese"],
+      "interactive_items": ["Mutagen Sample"],
+      "feature_item": {"mystical crystal": "place holder description"},
       "valid_moves": {"north": true, "south": false, "west": true, "east": false},
-      "description": "You enter the opulent throne room where the Pig Mutant King resides. The King sits atop a grand throne, emanating power and malice.",
+      "description": "You enter the opulent throne room where the Pig Mutant King resides. The King sits atop a grand throne, emanating power and malice. After a hard-fought battle, you emerge victorious, and the sound of jubilation draws you to the Triumphant Courtyard where your fellow resistance fighters gather to celebrate the downfall of the once formidable ruler.",
       "obj_description": "Next to the desk there is a mutagen sample.",
       "isPresent": true
     },
     "Room_10": {
-      "name": "Victory Celebration",
+      "name": "Triumphant Courtyard",
       "interactive_items": ["crown"],
+      "feature_item": {"victory banner": "place holder description"},
       "valid_moves": {"north": true, "south": false, "west": false, "east": false},
       "description": "The battle is won! You join the celebration with your fellow resistance fighters. The once-doomed Porktopia is now on its way to rebuilding and restoring peace.",
       "obj_description": "You see a crown on the ground. Claim it, it's yours!",

--- a/game/text_adventure.py
+++ b/game/text_adventure.py
@@ -2,7 +2,7 @@ from game.maps import Map
 from game.objects import Objects
 from game.player import Player
 from game.command_parser import CommandParser
-from game.verbs import hit_verb, pull_verb, eat_verb, look_verb, look_at_verb, inventory_verb, glance_verb
+from game.verbs import hit_verb, pull_verb, look_verb, look_at_verb, inventory_verb, glance_verb, read_verb
 import os
 
 
@@ -105,8 +105,8 @@ class TextAdventureGame:
             pull_verb(obj)
         elif verb == "go":
             self.move_player(obj)
-        elif verb == "eat":
-            eat_verb(obj)
+        elif verb == "read":
+            read_verb(obj)
         elif verb == "look":
             look_verb(self.player.current_room)
         elif verb == "glance":

--- a/game/verbs.py
+++ b/game/verbs.py
@@ -11,11 +11,11 @@ def pull_verb(object_to_pull):
     """
     print(f"You pull the {object_to_pull}.")
 
-def eat_verb(item_to_eat):
+def read_verb(object_to_read):
     """
-    Handle the "eat" verb action.
+    Handle the "read" verb action.
     """
-    print(f"You eat the {item_to_eat}.")
+    print(f"You read the {object_to_read}.")
 
 def look_verb(room):
     """


### PR DESCRIPTION
1. Updated map’s description with exits clearly defined to allow player to use verbs and preposition 4 different ways
2. Redid the last 10 features to make it more coercive to the additional verb interactions.
3. Removed the eat verb and added read
4. Still working on how to incorporate the features to only interact with the 3 verbs hit, pull and read. These features cannot be picked up and added to the inventory. Will continue when I am back.