### PR TITLE
Fixed the issue with dropping an item in a different room and showing description from Kat's last merge. See comments in discord.

### DIFF
--- a/data/maps.json
+++ b/data/maps.json
@@ -2,102 +2,92 @@
   "maps": {
     "Room_1": {
       "name": "Village Hut",
-      "interactive_items": ["torchlight"],
+      "interactive_items": {"torchlight":"There's an unlit torchlight on the ground beside you."},
       "feature_item": {"old wooden chest": "The force of your hit jolts the old wooden chest, leaving you intrigued about the concealed contents within and their potential significance on your journey to unravel the Abandoned Laboratory's mysteries."},
       "valid_moves": {"north": false, "south": false, "west": false, "east": true},
       "description": "Awakening in a rustic village hut, surrounded by tension and distant oinks, you're compelled to reach the Abandoned Laboratory, a place of intrigue and secrets. Despite your efforts, an inexplicable force keeps returning you to the hut, making you realize that understanding the village's mysteries is essential to unlocking the laboratory's enigma.",
-      "obj_description": "There's an unlit torchlight on the ground beside you and a peculiar old wooden chest in the corner of the room. Maybe, I can hit it to open it.",
-      "isPresent": true,
+      "feature_location_description": "A peculiar old wooden chest in the corner of the room. Maybe, I can hit it to open it.",
       "action_verb": "hit"
     },
     "Room_2": {
       "name": "Abandoned Laboratory",
-      "interactive_items": ["cast"],
+      "interactive_items": {"cast" : "In the dim light of the Abandoned Laboratory, your gaze falls upon a plaster cast, seemingly of great significance."},
       "feature_item": {"mysterious note": "Upon unfolding the aged parchment, you encounter a mysterious note adorned with inscrutable symbols and enigmatic messages, alluding to the long-forgotten experiments and the hidden secrets of the Abandoned Laboratory, as well as unveiling the location of an undiscovered ancient temple, beckoning you towards uncharted realms."},
       "valid_moves": {"north": false, "south": false, "west": true, "east": false},
       "description": "As you step into the dilapidated laboratory, you're greeted by the sight of shattered equipment and remnants of past experiments gone awry. The lingering stench of chemicals permeates the air, hinting at the space's former scientific pursuits. Amidst the debris, you catch a glimpse of a weathered map, which unexpectedly reveals a hidden secret - the location of an ancient temple yet to be discovered.",
-      "obj_description": "In the dim light of the Abandoned Laboratory, your gaze falls upon a plaster cast, seemingly of great significance, accompanied by a mysterious note hinting at its enigmatic purpose.",
-      "isPresent": true,
+      "feature_location_description": "In the mess on the desk you notice a mysterious note scribbled with inscrutable symbols and enigmatic messages. Maybe I can read it.",
       "action_verb": "read"
     },
     "Room_3": {
       "name": "Ancient Temple",
-      "interactive_items": ["communicator"],
+      "interactive_items": {"communicator" : "You see a dirty old communicator lying on the floor that might have significance." },
       "feature_item": {"ancient inscription": "Upon deciphering its contents, the ancient inscription reveals a labyrinth of cryptic symbols and inscriptions, enticingly providing elusive hints towards uncharted realms within the Ancient Temple and the sacred secrets concealed within the hidden crypt."},
       "valid_moves": {"north": false, "south": true, "west": true, "east": true},
       "description": "As you wander through the dense wilderness, you chance upon an age-old temple concealed in an aura of mystique. The air around you seems to vibrate with an otherworldly presence, and intricate enigmatic symbols decorate the temple walls, whispering untold secrets of the past. Amidst the palpable intrigue, you can't help but wonder if these symbols might guide you to a hidden crypt within the temple's depths.",
-      "obj_description": "In the midst of the Ancient Temple's enigmatic aura, your attention is drawn not only to the communicator that seems significant but also to an ancient inscription etched onto the temple walls, its labyrinth of cryptic symbols and inscriptions enticingly hinting at uncharted realms and the sacred secrets concealed within the hidden crypt",
-      "isPresent": true,
+      "feature_location_description": "Your attention is also drawn to all the interesting ancient inscriptions on the walls. Maybe I can read them.",
       "action_verb": "read"
     },
     "Room_4": {
       "name": "Hidden Crypt",
-      "interactive_items": ["Laser Shield"],
+      "interactive_items": {"Laser Shield":"There is a laser shield glowing on the far wall." },
       "feature_item": {"mysterious lever": "As you pull the lever, a deafening noise reverberates through the room, and in a moment of surprise, a hidden door creaks open, revealing a tantalizing glimpse of something unknown beyond."},
       "valid_moves": {"north": true, "south": true, "west": false, "east": true},
       "description": "As you venture deeper into the labyrinthine underground tunnels, an astounding revelation awaits - a concealed crypt, seemingly waiting to be unlocked. The walls of this hidden chamber bear cryptic engravings, speaking of an ancient and mysterious past. Remarkably, rows of age-old coffins line the dimly lit space, hinting at its potential use as a long-forgotten Resistance Hideout, where secrets and courage intertwine to challenge oppressive forces.",
-      "obj_description": "There is a laser shield glowing on the far wall and a peculiar looking lever to the side of the crypt. What will happen if I pull it?",
-      "isPresent": true,
+      "feature_location_description": "What is that peculiar looking lever to the side of the crypt. What will happen if I pull it?",
       "action_verb": "pull"
     },
     "Room_5": {
       "name": "Resistance Hideout",
-      "interactive_items": ["blueprints"],
+      "interactive_items": {"blueprints" :"There are blueprints on the ground."},
       "feature_item": {"locked cabinet": "Exerting force, you yank open the locked cabinet, causing a myriad of items to spill out in disarray, but nothing of value was found."},
       "valid_moves": {"north": false, "south": true, "west": false, "east": true},
       "description": "As you stealthily make your way through hidden passages, you stumble upon the clandestine hideout of the resistance group. The atmosphere hums with energy and purpose as courageous fighters congregate, diligently strategizing and arming themselves for the imminent battle within the Reactor Tunnels.",
-      "obj_description": "There are blueprints on the ground and a locked cabinet in the corner of the room. The lock looks weak maybe pulling it can free it.",
-      "isPresent": true,
+      "feature_location_description": "You notice a locked cabinet in the corner of the room. The lock looks weak maybe pulling it can free it.",
       "action_verb": "pull"
     },
     "Room_6": {
       "name": "Reactor Tunnels",
-      "interactive_items": ["cell"],
+      "interactive_items": {"cell": "There is a power cell in the corner of the room."},
       "feature_item": {"strange vines": "You eagerly pull at the strange vines, hoping for a special response, but they remain unyielding, revealing nothing of significance."},
       "valid_moves": {"north": false, "south": true, "west": true, "east": false},
       "description": "As you cautiously tread through dim and foreboding tunnels, you draw closer to the heart of the reactor. The atmosphere becomes thick with radiation, and the distant reverberation of machinery creates an unsettling ambiance. The eerie surroundings fuel your trepidation, raising the possibility that you might stumble upon the dreaded torture chamber hidden within the depths.",
-      "obj_description": "There is a power cell in the corner of the room and a ton of strange vines hanging from the ceiling. Maybe pulling it might review something.",
-      "isPresent": true,
+      "feature_location_description": "Why is there a ton of strange vines hanging from the ceiling. Maybe pulling it might review something.",
       "action_verb": "pull"
     },
     "Room_7": {
       "name": "Torture Chamber",
-      "interactive_items": ["cutter"],
+      "interactive_items": {"cutter" : "There is a plasma cutter on the ground."},
       "feature_item": {"amulet": "Upon striking the amulet with force, a surge of mystical energy envelops the player, empowering them with a radiant aura that enhances their abilities."},
       "valid_moves": {"north": true, "south": true, "west": true, "east": true},
       "description": "As you explore further, you come across a chilling sight - a gruesome torture chamber, serving as a nightmarish prison for captured villagers who endure unspeakable horrors. The room is adorned with ominous devices that elicit fear, and the haunting echoes of agonizing cries fill the air, hinting at the ominous presence of the Pig Mutant Stronghold lurking nearby.",
-      "obj_description": "There is a plasma cutter on the ground and a dazzling amulet that exudes a radiant glow. It looks like there is something inside, should I hit it?",
-      "isPresent": true,
+      "feature_location_description": "In the far corner there is a radiant glow coming from what looks like an amulet. It looks like there is something inside, should I hit it?",
       "action_verb": "hit"
     },
     "Room_8": {
       "name": "Pig Mutant Stronghold",
-      "interactive_items": ["message"],
+      "interactive_items": {"message": "There is a crumpled looking message on the ground."},
       "feature_item": {"mysterious mural": "As you study the mysterious mural, it depicts the fearsome Pig Mutant King in all his malevolent glory, serving as a grim reminder of the oppressive ruler that holds sway over the stronghold."},
       "valid_moves": {"north": false, "south": true, "west": true, "east": true},
       "description": "As you approach the imposing fortified stronghold, you find yourself standing before the grand entrance to the Pig Mutant King's throne room. The area is heavily guarded, and the air reverberates with the haunting cries of resistance members who have been captured and subjected to unspeakable torment.",
-      "obj_description": "There is a crumpled looking message on the ground and a mysterious mural off in the distance. It's hard to read it from here.",
-      "isPresent": true,
+      "feature_location_description": "A mysterious mural is off in the distance. It's hard to read it from here. Maybe, I should get closer to try to read it.",
       "action_verb": "read"
     },
     "Room_9": {
       "name": "Throne Room",
-      "interactive_items": ["Mutagen Sample"],
+      "interactive_items": {"Mutagen Sample": "There is a mutagen sample on the desk."},
       "feature_item": {"mystical crystal": " Intuitively, you strike the crystal, and a surge of empowering energy courses through you, bestowing enhanced abilities to aid you in the final confrontation against the Pig Mutant King."},
       "valid_moves": {"north": true, "south": false, "west": true, "east": false},
       "description": "You enter the opulent throne room where the Pig Mutant King resides. The King sits atop a grand throne, emanating power and malice. After a hard-fought battle, you emerge victorious, and the sound of jubilation draws you to the Triumphant Courtyard where your fellow resistance fighters gather to celebrate the downfall of the once formidable ruler.",
-      "obj_description": "Next to the desk there is a mutagen sample and hidden admist it is a mystical crystal. Something from the crystal is calling me to hit it.",
-      "isPresent": true,
+      "feature_location_description": "Hidden admist the room there is a mystical crystal. Something from the crystal is calling me to hit it.",
       "action_verb": "hit"
     },
     "Room_10": {
       "name": "Triumphant Courtyard",
-      "interactive_items": ["crown"],
-      "feature_item": {"victory bell": "As the joyful sound of the Victory Bell reverberates through the courtyard, the brave resistance fighters celebrate their hard-won victory over the tyrannical Pig Mutant King, restoring peace and hope to the once-doomed land of Porktopia. The people gather to honor their valiant heroes, and the vibrant energy of unity fills the air, marking the end of an epic saga of courage and determination. Game over. Congratulations on leading Porktopia to freedom and vanquishing the Pig Mutant King's rule!"},
+      "interactive_items": {"crown": "In the midst of celebration, you find a crown waiting to be claimed."},
+      "feature_item": {"victory bell": "As the joyful sound of the Victory Bell reverberates through the courtyard, the brave resistance fighters celebrate their hard-won victory over the tyrannical Pig Mutant King, restoring peace and hope to the once-doomed land of Porktopia. The people gather to honor their valiant heroes, and the vibrant energy of unity fills the air, marking the end of an epic saga of courage and determination. Congratulations on leading Porktopia to freedom and vanquishing the Pig Mutant King's rule! Game over."},
       "valid_moves": {"north": true, "south": true, "west": true, "east": true},
       "description": "The battle is won! You join the celebration with your fellow resistance fighters. The once-doomed Porktopia is now on its way to rebuilding and restoring peace.",
-      "obj_description": "In the midst of celebration, you find a crown waiting to be claimed, and a Victory Bell invites you to pull its rope, resounding the triumph over the Pig Mutant King.",
-      "isPresent": true,
+      "feature_location_description": "A Victory Bell invites you to pull its rope, resounding the triumph over the Pig Mutant King.",
       "action_verb": "pull"
     }
   }

--- a/data/objects.json
+++ b/data/objects.json
@@ -52,7 +52,7 @@
     },
     "blueprints": {
       "name": "Reactor Blueprints",
-      "description": "Detailed schematics of the reactor's layout and weaknesses.",
+      "description": "detailed schematics of the reactor's layout and weaknesses.",
       "effect": "Provides crucial information for infiltrating and sabotaging the reactor.",
       "equipped": false,
       "verbs": ["use", "examine", "study"],
@@ -92,7 +92,7 @@
     },
     "crown": {
       "name": "Mutant King's Crown",
-      "description": "The crown of the defeated Pig Mutant King.",
+      "description": "the crown of the defeated Pig Mutant King.",
       "effect": "Symbolizes player's victory and can be put on display during the epilogue.",
       "equipped": false,
       "verbs": ["use", "examine", "display"],

--- a/game/command_parser.py
+++ b/game/command_parser.py
@@ -22,7 +22,7 @@ class CommandParser:
         prepositions = CommandParser.identify_prepositions(command)
 
         # Player typed the room name directly
-        if command.lower() in map.get_room_names():
+        if command.lower() in map.get_list_of_room_names():
             return "move", command.lower()
         # Player used single-word direction
         elif command.lower() in ["north", "south", "east", "west"]:

--- a/game/inventory.py
+++ b/game/inventory.py
@@ -11,19 +11,13 @@ class Inventory:
     def get_item(self, item_name):
         return self.items.get(item_name)
 
-    def add_item(self, item_name, quantity=1):
+    def add_item(self, item_name, item_location):
+        self.items[item_name] = item_location
+        
+    def remove_item(self, item_name):
         if item_name in self.items:
-            self.items[item_name] += quantity
-        else:
-            self.items[item_name] = quantity
-
-    def remove_item(self, item_name, quantity=1):
-        if item_name in self.items:
-            if self.items[item_name] >= quantity:
-                self.items[item_name] -= quantity
-                if self.items[item_name] == 0:
-                    del self.items[item_name]
-                return True
+            del self.items[item_name]
+            return True
         return False
 
     def view_inventory(self):

--- a/game/maps.py
+++ b/game/maps.py
@@ -59,7 +59,7 @@ class Map:
 
         return self.map_data[room_keys[self.room_count]]
 
-    def get_room_names(self):
+    def get_list_of_room_names(self):
         """Returns a list of room names"""
         return [self.map_data[room_key]["name"].lower() for room_key in self.map_data]
 

--- a/game/objects.py
+++ b/game/objects.py
@@ -30,15 +30,14 @@ class Objects:
 
     def get_object(self, object_name):
         """Returns the object data based on the given object name"""
-        for obj_key in self.objects:
-            obj = self.objects[obj_key]
-            if obj['name'].lower() == object_name.lower():
-                return obj
+        for obj_key, obj_value in self.objects.items():
+            if obj_key.lower() == object_name.lower():
+                return obj_value
         return None
 
-    
-    def set_object_presence(self, item_name, is_present):
-        item = self.get_object(item_name)
 
-        if item:
-            item["isPresent"] = is_present
+    # def set_object_presence(self, item_name, is_present):
+    #     item = self.get_object(item_name)
+
+    #     if item:
+    #         item["isPresent"] = is_present

--- a/game/player.py
+++ b/game/player.py
@@ -68,29 +68,25 @@ class Player:
 
     def take_item_from_room(self, item):
         item = item.lower()
-        # looks for item and removes it from player room instance
 
         for room_item in self.current_room["interactive_items"]:
             if item == room_item.lower():
-                self.current_room["interactive_items"].remove(room_item)
-                self.current_room["isPresent"] = False
-                return room_item
+                item_location = self.current_room["interactive_items"].pop(room_item)
+                return room_item, item_location
         return None
     
     
-    def add_item_to_room(self, item):
-        self.current_room["interactive_items"].append(item)
-        self.objects.set_object_presence(item, True)
+    def add_item_to_room(self, item, location):
+        self.current_room["interactive_items"].update({item: location})
+        # self.objects.set_object_presence(item, True)
         print(f"You've added the {item} to the room.")
 
 
     def drop_item(self, item):
-        item_data = self.objects.get_object(item)
-
-        inventory_item = self.inventory.get_item(item)
-        if inventory_item:
-            self.add_item_to_room(item)
-            self.inventory.remove_item(item)
+        inventory_item__value = self.inventory.get_item(item)
+        if inventory_item__value:
+            self.add_item_to_room(item.lower(), inventory_item__value)
+            self.inventory.remove_item(item.lower())
             print(f"You dropped the {item}.")
         else:
             print("You don't have that item in your inventory.")

--- a/game/text_adventure.py
+++ b/game/text_adventure.py
@@ -137,11 +137,10 @@ class TextAdventureGame:
         self.player.move(direction.strip())
 
     def take_item(self, item):
-        item_data = self.player.take_item_from_room(item)
-        if item_data:
-            self.player.inventory.add_item(item_data, quantity=1)
-            self.player.current_room["isPresent"] = False
-            print(f"You picked up {item_data}")
+        item_name, item_location = self.player.take_item_from_room(item)
+        if item_name:
+            self.player.inventory.add_item(item_name, item_location)
+            print(f"You picked up {item_name}")
         else:
             print("There is no such item in this room.")
 
@@ -220,13 +219,13 @@ class TextAdventureGame:
             print("Invalid command.")
 
     def play(self):
-        self.check_terminal_size()
+        # self.check_terminal_size()
 
         print(
             f"\nWelcome to the game {self.player.get_name()}! Type help for a list of commands. \nNot sure what to do first? Get started by looking around the room with 'look'.")
 
         while True:
-            self.check_terminal_size()  
+            # self.check_terminal_size()  
 
             print("\nWhat will you do next?")
 

--- a/game/verbs.py
+++ b/game/verbs.py
@@ -30,10 +30,10 @@ def look_verb(room):
     """
     Handle the "look" verb action. Repeats the long form explanation of the room
     """
-    if room["isPresent"] == True:
-        print(f"{room['description']} \n\n{room['obj_description']}")
-    else:
-        print(room['description'])
+    print(f"{room['description']} \n\n")
+    for _, item_location in room['interactive_items'].items():
+        print(f"{item_location} ", end="")
+    print(room['feature_location_description'])
 
 def glance_verb(room, inventory, objects, obj):
     """
@@ -70,7 +70,7 @@ def look_at_verb(room, inventory, objects, obj):
         if obj_in_inventory:
             print(f"You found the {obj_in_inventory} in your inventory.")
             if item_description:
-                print(f"You see {item_description}")
+                print(f"{item_description}")
             else:
                 print(f"You look at the {obj_in_inventory} but find nothing of interest.")
         else:
@@ -92,5 +92,5 @@ def inventory_verb(inventory):
         print("It looks like you don't have anything in your inventory.")
     else:
         print("Inventory:")
-        for item, quantity in inventory.view_inventory().items():
-            print(f"- {item}: {quantity}")
+        for item in inventory.view_inventory().keys():
+            print(f"- {item}: 1")


### PR DESCRIPTION
1. Updated map.json to change interactive items from a list to a dictionary with the item location description as the value of the item.
2. Changed obj_description in maps.json to feature_location_description
3. Fixed drop method to accommodate the change in interactive items from being a list to a dictionary
4. Modified inventory add item and remove item to not include the quantity and to add a key value pair or to delete from a dictionary instead of a list. The quantity is automatically set to 1 in the inventory verb when it prints the player’s inventory.
5. Updated player’s add_item_to_room to accommodate adding a key value pair to the interactive item dictionary.
6. Updated player take_item_from_room to accommodate removing from a dictionary and saving the deleted item as a key value pair that is returned so it can be added as a key value pair to the player’s inventory.
7. Removed isPresent from the maps.json 