### PR TITLE
Update save/load, 'use', and 'move' functionalities

### DIFF
--- a/game/command_parser.py
+++ b/game/command_parser.py
@@ -17,7 +17,7 @@ class CommandParser:
         verbs = ["move", "take", "use", "quit", "hit", "pull", "glance", "glance at", "go", "look", "inventory",
                  "examine", "show", "turn on", "turn off", "insert", "upgrade", "study", "cut", "activate", "deactivate",
                  "decipher", "display", "help", "drop", "look at", "read", "pick up", "exit", "analyze",
-                 "strike", "push", "open", "tug", "yank", "grab", "save", "load", "reset backups"]
+                 "strike", "push", "open", "tug", "yank", "grab", "save", "load", "reset backups", "reset backup", "reset"]
 
         prepositions = CommandParser.identify_prepositions(command)
 

--- a/game/objects.py
+++ b/game/objects.py
@@ -35,9 +35,14 @@ class Objects:
                 return obj_value
         return None
 
+    def mark_item_as_equipped(self, item_name):
+        """Marks the specified item as equipped"""
+        item_data = self.get_object(item_name)
+        if item_data:
+            item_data["equipped"] = True
 
-    # def set_object_presence(self, item_name, is_present):
-    #     item = self.get_object(item_name)
-
-    #     if item:
-    #         item["isPresent"] = is_present
+    def handle_item_effect(self, item_name):
+        """Handles the effect of using the specified item"""
+        item_data = self.get_object(item_name)
+        if item_data:
+            print(item_data["effect"])

--- a/game/player.py
+++ b/game/player.py
@@ -43,7 +43,7 @@ class Player:
                 self.current_room = next_room
                 self.map.set_current_room(self.current_room)
                 self.map.increment_room_count()
-                print(f"You move to {self.current_room['name']}.")
+                print(f"You move to the {self.current_room['name']}.")
                 return
             # Check if command is a direction
             elif self.map.is_move_valid(destination.lower()):
@@ -51,7 +51,7 @@ class Player:
                 self.current_room = next_room
                 self.map.set_current_room(self.current_room)
                 self.map.increment_room_count()
-                print(f"You move to {self.current_room['name']}")
+                print(f"You move to the {self.current_room['name']}")
                 return
             else:
                 print(


### PR DESCRIPTION
1. Update save/load to use maps['interactive items'] rather than objects['isPresent']. Added in more command words to reset the save progress.
2. Implemented 'use' command to use the item when equipped. 
3. Updated 'move' to print room descriptions when the player moves into a new room. 